### PR TITLE
Fix regressive behaviour introduced in `patchwise_train`

### DIFF
--- a/deepsensor/data/loader.py
+++ b/deepsensor/data/loader.py
@@ -854,29 +854,25 @@ class TaskLoader:
                 coord_x2_top= var.x2[0]
                 coord_x2_bottom= var.x2[-1]
             
+                x1_ascend = True if coord_x1_left <= coord_x1_right else False
+                x2_ascend = True if coord_x2_top <= coord_x2_bottom else False
+
+                coord_directions = {
+                        "x1": x1_ascend,
+                        "x2": x2_ascend,
+                    }
+
             #TODO- what to input for pd.dataframe
             elif isinstance(var, (pd.DataFrame, pd.Series)):
-                var_x1_min = var.index.get_level_values("x1").min()
-                var_x1_max = var.index.get_level_values("x1").max()
-                var_x2_min = var.index.get_level_values("x2").min()
-                var_x2_max = var.index.get_level_values("x2").max()
+                # var_x1_min = var.index.get_level_values("x1").min()
+                # var_x1_max = var.index.get_level_values("x1").max()
+                # var_x2_min = var.index.get_level_values("x2").min()
+                # var_x2_max = var.index.get_level_values("x2").max()
 
-            x1_ascend = True
-            x2_ascend = True
-            if coord_x1_left < coord_x1_right:
-                x1_ascend = True
-            if coord_x1_left > coord_x1_right:
-                x1_ascend = False
-
-            if coord_x2_top < coord_x2_bottom:
-                x2_ascend = True
-            if coord_x2_top > coord_x2_bottom:
-                x2_ascend = False
-
-        coord_directions = {
-                "x1": x1_ascend,
-                "x2": x2_ascend,
-            }
+                coord_directions = {
+                    "x1": None,
+                    "x2": None
+                }
 
         return coord_directions 
 

--- a/deepsensor/data/loader.py
+++ b/deepsensor/data/loader.py
@@ -842,7 +842,7 @@ class TaskLoader:
         Returns
         -------
         coord_directions: dict(str)
-            String containing two booleans: x1_ascend and x2_ascend, 
+            Dictionary containing two keys: x1 and x2, with boolean values
             defining if these coordings increase or decrease from top left corner. 
  
         """      
@@ -853,7 +853,8 @@ class TaskLoader:
                 coord_x1_right= var.x1[-1]
                 coord_x2_top= var.x2[0]
                 coord_x2_bottom= var.x2[-1]
-            #Todo- what to input for pd.dataframe
+            
+            #TODO- what to input for pd.dataframe
             elif isinstance(var, (pd.DataFrame, pd.Series)):
                 var_x1_min = var.index.get_level_values("x1").min()
                 var_x1_max = var.index.get_level_values("x1").max()
@@ -871,8 +872,6 @@ class TaskLoader:
                 x2_ascend = True
             if coord_x2_top > coord_x2_bottom:
                 x2_ascend = False
-
-
 
         coord_directions = {
                 "x1": x1_ascend,

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -3,7 +3,7 @@ import itertools
 import tempfile
 
 from parameterized import parameterized
-from hypothesis import example, given, strategies as st
+from hypothesis import given, settings, strategies as st
 
 import os
 import xarray as xr
@@ -555,6 +555,7 @@ class TestModel(unittest.TestCase):
             model.predict(task, X_t=self.da, pred_params=["invalid_param"])
 
     @given(st.data())
+    @settings(deadline=None)
     def test_patchwise_prediction(self, data):
         """Test that ``.predict_patch`` runs correctly."""
 

--- a/tests/test_task_loader.py
+++ b/tests/test_task_loader.py
@@ -386,19 +386,19 @@ class TestTaskLoader(unittest.TestCase):
 
     @parameterized.expand(
     [
-        ("sliding", (0.5, 0.5), (0.6, 0.6)), # patch_size and stride as tuples
-        ("sliding", 0.5, 0.6),               # as floats
-        ("sliding", 1.0, 1.2),               # one argument above allowed range
-        ("sliding", -0.1, 0.6),              # and below allowed range
-        ("random", 1.1, None)                # for sliding window as well
+        ("sliding", (0.5, 0.5), (0.6, 0.6), Warning), # patch_size and stride as tuples
+        ("sliding", 0.5, 0.6, Warning),               # as floats
+        ("sliding", 1.0, 1.2, Warning),               # one argument above allowed range
+        ("sliding", -0.1, 0.6, Warning),              # and below allowed range
+        ("random", 1.1, None, ValueError)                # for sliding window as well
     ]
     )
-    def test_patchwise_task_loader_parameter_handling(self, patch_strategy, patch_size, stride):
+    def test_patchwise_task_loader_parameter_handling(self, patch_strategy, patch_size, stride, raised):
         """Test that correct errors and warnings are raised by ``.predict_patch``."""
 
         tl = TaskLoader(context=self.da, target=self.da)
 
-        with self.assertRaises(ValueError):
+        with self.assertRaises(raised):
             tl(
                 "2020-01-01",
                 context_sampling="all",

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -131,7 +131,7 @@ class TestTraining(unittest.TestCase):
             context_sampling="all",
             target_sampling="all",
             patch_strategy="random",
-            patch_size=(0.8, 0.8),
+            patch_size=(0.4, 0.8),
         )
 
         # TODO pytest can also be more succinct with pytest.fixtures


### PR DESCRIPTION
I'm working my way through all the failing tests caused by changes in `patchwise_train` that we haven't picked up on.

In particular, I need some feedback on `TaskLoader._compute_x1x2_direction`

I've made an attempt at just having it return a dictionary with `None` values in the case of pandas data, since this isn't then accessed again in that case. But I don't particularly like it. It would be better to not run this method at all for that data, or exit quite quickly.

Another observation about this function and its usage, it returns a dictionary with boolean values for `x1` & `x2`, which is assigned into a variable called `coord_directions` - generally from a style point of view, it's nice for variables and their contents to be self-explanatory. So perhaps it might be better to call this variable `coord_ascending` or `coord_direction` and have the values be `increasing`/`decreasing` or something. This may seem like a nitpick, but it helps with code-readability in the future.

resolves #3 