### PR TITLE
Addressing Monotonic coordinates error in model.py  

### DIFF
--- a/deepsensor/data/loader.py
+++ b/deepsensor/data/loader.py
@@ -191,7 +191,7 @@ class TaskLoader:
         ) = self.infer_context_and_target_var_IDs()
 
         self.coord_bounds = self._compute_global_coordinate_bounds()
-        self.coord_directions = self._compute_x1x2_direction()
+        self.coord_ascending_from_top_left = self._compute_coord_ascend_from_top_left()
 
     def _set_config(self):
         """Instantiate a config dictionary for the TaskLoader object"""
@@ -835,9 +835,9 @@ class TaskLoader:
 
         return [x1_min, x1_max, x2_min, x2_max]
     
-    def _compute_x1x2_direction(self) -> str:
+    def _compute_coord_ascend_from_top_left(self) -> str:
         """
-        Compute whether the x1 and x2 coords are ascending or descending.
+        Compute whether the x1 and x2 coords are ascending or descending from top left corner.
 
         Returns
         -------
@@ -854,11 +854,27 @@ class TaskLoader:
                 coord_x2_top= var.x2[0]
                 coord_x2_bottom= var.x2[-1]
             #Todo- what to input for pd.dataframe
-            elif isinstance(var, (pd.DataFrame, pd.Series)):
+            elif isinstance(var, (pd.DataFrame, pd.Series)): 
+                # Steps to find coordinate direction if using pandas
+                # 1. Find min/max x1 and x2
+                # 2. Unnormalise to find corresponding coordinates of x1/x2 min/max
+                # 3. Use same rules as with xarray to set x1_ascend and x2_ascend to true or false.              
                 var_x1_min = var.index.get_level_values("x1").min()
                 var_x1_max = var.index.get_level_values("x1").max()
                 var_x2_min = var.index.get_level_values("x2").min()
                 var_x2_max = var.index.get_level_values("x2").max()
+                x1_minmax = xr.DataArray([var_x1_min, var_x1_max], dims="x1", name="x1")
+                x2_minmax = xr.DataArray([var_x2_min, var_x2_max], dims="x2", name="x2")
+                x1x2_minmax = xr.Dataset(coords={"x1": x1_minmax, "x2": x2_minmax})
+
+                # TODO current error message as data_processor is not imported. 
+                orig_x1_name = data_processor.x1_name
+                orig_x2_name = data_processor.x2_name
+
+                # Unnormalise coordinates of min and max of x1 and x2
+                overlap_unnorm_xr = data_processor.unnormalise(x1x2_minmax)
+                coord_x1_left, coord_x1_right = overlap_unnorm_xr.coords[orig_x1_name]
+                coord_x2_top, coord_x2_bottom = overlap_unnorm_xr.coords[orig_x2_name]
 
             x1_ascend = True
             x2_ascend = True
@@ -1478,7 +1494,7 @@ class TaskLoader:
         patch_list = []
 
         # Todo: simplify these elif statements
-        if self.coord_directions['x1'] == False and self.coord_directions['x2'] == True:
+        if self.coord_ascending_from_top_left['x1'] == False and self.coord_ascending_from_top_left['x2'] == True:
             for y in np.arange(x1_max, x1_min, -dy):
                 for x in np.arange(x2_min, x2_max, dx):
                     if y - x1_extend < x1_min:
@@ -1494,7 +1510,7 @@ class TaskLoader:
                     bbox = [y0 - x1_extend, y0, x0, x0 + x2_extend]
                     patch_list.append(bbox)
 
-        elif self.coord_directions['x1'] == False and self.coord_directions['x2'] == False:
+        elif self.coord_ascending_from_top_left['x1'] == False and self.coord_ascending_from_top_left['x2'] == False:
             for y in np.arange(x1_max, x1_min, -dy):
                 for x in np.arange(x2_max, x2_min, -dx):
                     if y - x1_extend < x1_min:
@@ -1510,7 +1526,7 @@ class TaskLoader:
                     bbox = [y0 - x1_extend, y0, x0 - x2_extend, x0]
                     patch_list.append(bbox)
 
-        elif self.coord_directions['x1'] == True and self.coord_directions['x2'] == False:
+        elif self.coord_ascending_from_top_left['x1'] == True and self.coord_ascending_from_top_left['x2'] == False:
             for y in np.arange(x1_min, x1_max, dy):
                 for x in np.arange(x2_max, x2_min, -dx):
                     if y + x1_extend > x1_max:

--- a/deepsensor/model/model.py
+++ b/deepsensor/model/model.py
@@ -836,7 +836,6 @@ class DeepSensorModel(ProbabilisticModel):
                 if x1:
                     coord_index = np.argmin(np.abs(X_t.coords[orig_x1_name].values - patch_coord))
                 else:
-                    print('i am getting at the x2 coords')
                     coord_index = np.argmin(np.abs(X_t.coords[orig_x2_name].values - patch_coord)) 
                 return coord_index
 
@@ -886,8 +885,6 @@ class DeepSensorModel(ProbabilisticModel):
 
             data_x1_index, data_x2_index = get_index(data_x1, data_x2)
             patches_clipped = {var_name: [] for var_name in patch_preds[0].keys()}
-            print('x1/x2 direction', x1_ascend, x2_ascend)
-            print('image extent in x1/x2', data_x1_index[0], data_x1_index[1], data_x2_index[0], data_x2_index[1])
 
             for i, patch_pred in enumerate(patch_preds):
                 for var_name, data_array in patch_pred.items():
@@ -905,8 +902,6 @@ class DeepSensorModel(ProbabilisticModel):
                         
                         b_x1_min, b_x1_max = patch_overlap[0], patch_overlap[0]
                         b_x2_min, b_x2_max = patch_overlap[1], patch_overlap[1]
-                        print('patch location', patch_x1_index[0], patch_x1_index[1], patch_x2_index[0], patch_x2_index[1])
-                        print('Original patch overlap', b_x1_min, b_x1_max, b_x2_min, b_x2_max)
                         """
                         Do not remove border for the patches along top and left of dataset and change overlap size for last patch in each row and column.
                         
@@ -928,7 +923,6 @@ class DeepSensorModel(ProbabilisticModel):
                             if x2_ascend:
                                 prev_patch_x2_max = get_index((patch_row_prev[var_name].coords[orig_x2_name].max()), x1 = False)
                                 b_x2_min = (prev_patch_x2_max - patch_x2_index[0])-patch_overlap[1]
-                                print('whats going on', prev_patch_x2_max, patch_x2_index[0], patch_overlap[1])
                             else:
                                 prev_patch_x2_min = get_index((patch_row_prev[var_name].coords[orig_x2_name].min()), x1 = False)
                                 b_x2_min = (patch_x2_index[0] -prev_patch_x2_min)-patch_overlap[1]
@@ -945,16 +939,12 @@ class DeepSensorModel(ProbabilisticModel):
                                 prev_patch_x1_min = get_index((patch_prev[var_name].coords[orig_x1_name].min()), x1 = True)
 
                                 b_x1_min = (prev_patch_x1_min- patch_x1_index[0])- patch_overlap[0]
-                                print('whats going on', prev_patch_x1_min, patch_x1_index[0], patch_overlap[0])     
 
                         patch_clip_x1_min = int(b_x1_min)
                         patch_clip_x1_max = int(data_array.sizes[orig_x1_name] - b_x1_max)
                         patch_clip_x2_min = int(b_x2_min)
                         patch_clip_x2_max = int(data_array.sizes[orig_x2_name] - b_x2_max)
-                        print('borders', b_x1_min, b_x1_max, b_x2_min, b_x2_max)
-                        print('clipped patch extent', patch_clip_x1_min, patch_clip_x1_max, patch_clip_x2_min, patch_clip_x2_max)
-                        print('clipped patch location', patch_x1_index[0] + b_x1_min, patch_x1_index[1] - b_x1_max, 
-                              patch_x2_index[0] + b_x2_min, patch_x2_index[1] - b_x2_max)
+                        patch_x2_index[0] + b_x2_min, patch_x2_index[1] - b_x2_max)
                         patch_clip = data_array.isel(**{orig_x1_name: slice(patch_clip_x1_min, patch_clip_x1_max),
                                                         orig_x2_name: slice(patch_clip_x2_min, patch_clip_x2_max)})
 


### PR DESCRIPTION
When running `stitch_clipped_predictions()` in `model.py`, if the patch-wise predictions have overlapping coordinates, an error from `xr.combine_by_coords` is raised stating that the coordinates of the arrays to be combined are not monotonic in dimension {dim}. 

This was being caused by the use of int() in lines 925, 928, 937 and 940. The use of int() was eventually resulting in patches with negative borders, causing the monotonic error to come about. 

To address the issue, this PR remove this use of int().

ps, there are a lot of prints() to delete :) 