### PR TITLE
Move spatial slicing after spatial sampling

### DIFF
--- a/deepsensor/data/loader.py
+++ b/deepsensor/data/loader.py
@@ -1259,19 +1259,6 @@ class TaskLoader:
             for var, delta_t in zip(self.target, self.target_delta_t)
         ]
 
-        # check bbox size
-        if bbox is not None:
-            assert (
-                len(bbox) == 4
-            ), "bbox must be a list of length 4 with [x1_min, x1_max, x2_min, x2_max]"
-
-            # spatial slices
-            context_slices = [
-                self.spatial_slice_variable(var, bbox) for var in context_slices
-            ]
-            target_slices = [
-                self.spatial_slice_variable(var, bbox) for var in target_slices
-            ]
 
         # TODO move to method
         if (
@@ -1392,6 +1379,20 @@ class TaskLoader:
 
                     context_slices[context_idx] = context_var
                     target_slices[target_idx] = target_var
+        
+        # check bbox size
+        if bbox is not None:
+            assert (
+                len(bbox) == 4
+            ), "bbox must be a list of length 4 with [x1_min, x1_max, x2_min, x2_max]"
+
+            # spatial slices
+            context_slices = [
+                self.spatial_slice_variable(var, bbox) for var in context_slices
+            ]
+            target_slices = [
+                self.spatial_slice_variable(var, bbox) for var in target_slices
+            ]
 
         for i, (var, sampling_strat) in enumerate(
             zip(context_slices, context_sampling)


### PR DESCRIPTION
This PR addresses the loop that hangs indefinitely when applying the gapfill strategy to patched tasks. The issue is that some patches will either have complete data everywhere, or be full of Nans due to the position of the cloud masks.

In general, there is an issue that the sampling stategy, whether this is gapfill, split or int, should occur before patching the context and sampling sets. This PR moves the spatial sampling code below the code to carry out the spatial sampling.