### PR TITLE
Replace combine_by_coords with np.where() to stich patched predictions

### DIFF
--- a/deepsensor/model/model.py
+++ b/deepsensor/model/model.py
@@ -851,7 +851,7 @@ class DeepSensorModel(ProbabilisticModel):
                     trim_size = np.argmin(pixel_coords_overlap_diffs) / 2
                     trim_size_rounded = int(
                         np.floor(trim_size)
-                    )  # Always round down trim slide as new method can handle slight overlaps
+                    )  # Always round down trim slide as stitching method can handle slight overlaps
                     return trim_size_rounded
 
                 else:
@@ -1100,7 +1100,7 @@ class DeepSensorModel(ProbabilisticModel):
                         orig_x2_name: X_t[orig_x2_name],
                         "time": first_patchwise_pred["time"],
                     }
-                )  # Is this fine or can 'time' assume a different name?'
+                )
 
                 # Set variable names to those in patched predictions, set values to Nan.
                 for var_name_i in first_patchwise_pred.data_vars:

--- a/deepsensor/model/model.py
+++ b/deepsensor/model/model.py
@@ -1011,7 +1011,6 @@ class DeepSensorModel(ProbabilisticModel):
                         """
                         if patch_x2_index[0] == data_x2_index[0]:
                             b_x2_min = 0
-                            # The +1 operations here and elsewhere in this block address the different shapes between the input and prediction
                             # TODO: Try to resolve this issue in data/loader.py by ensuring patches are perfectly square.
                             b_x2_max = b_x2_max
                         elif patch_x2_index[1] == data_x2_index[1]:

--- a/deepsensor/model/model.py
+++ b/deepsensor/model/model.py
@@ -1085,11 +1085,42 @@ class DeepSensorModel(ProbabilisticModel):
 
                         patches_clipped[var_name].append(patch_clip)
 
+            #combined = patches_clipped[0]  # Start with the first patch
+            """
+            combined = {}
+            for var_name, patches in patches_clipped.items():
+                combined[var_name] = patches[0]  # Start with the first patch
+                for patch in patches[1:]:
+                    combined[var_name] = xr.merge([combined[var_name], patch], compat='no_conflicts', combine_attrs="override")
+            """
+            combined = {}
+            for var_name, patches in patches_clipped.items():
+                combined[var_name] = patches[0]  # Start with the first patch
+                for patch in patches[1:]:
+                    # Merge the current combined patch with the next one
+                    combined[var_name] = xr.merge([combined[var_name], patch], compat="override", combine_attrs="override")
+
+            """
+            combined = {}
+            for var_name, patches in patches_clipped.items():
+                combined[var_name] = patches[0]  # Start with the first patch
+                for patch in patches[1:]:
+                    combined[var_name] = combined[var_name].update(patch)
+            #print(patches_clipped)
+            #for patches in patches_clipped[1:]:
+            #    print('patches')
+            
+                combined = {
+                var_name: xr.merge([combined, patches], combine_attrs="override")
+                for var_name, patches in patches_clipped.items()
+            }
+                #combined = xr.merge([combined, patch], combine_attrs="override")  
+            
             combined = {
                 var_name: xr.combine_by_coords(patches, compat="no_conflicts")
                 for var_name, patches in patches_clipped.items()
             }
-
+            """
             return combined
 
         # load patch_size and stride from task

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -743,17 +743,17 @@ def test_patchwise_prediction():
     # gridded predictions
     assert [isinstance(ds, xr.Dataset) for ds in pred.values()]
     # TODO come back to this, for artificial datasets here, shapes of predictions don't match inputs
-    # for var_ID in pred:
-    #     assert_shape(
-    #         pred[var_ID]["mean"],
-    #         (1, da.x1.size, da.x2.size),
-    #     )
-    #     assert_shape(
-    #         pred[var_ID]["std"],
-    #         (1, da.x1.size, da.x2.size),
-    #     )
-    #     assert da.x1.size == pred[var_ID].x1.size
-    #     assert da.x2.size == pred[var_ID].x2.size
+    for var_ID in pred:
+        assert_shape(
+            pred[var_ID]["mean"],
+            (1, da.x1.size, da.x2.size),
+        )
+        assert_shape(
+            pred[var_ID]["std"],
+            (1, da.x1.size, da.x2.size),
+        )
+        assert da.x1.size == pred[var_ID].x1.size
+        assert da.x2.size == pred[var_ID].x2.size
 
 def assert_shape(x, shape: tuple):
     """Assert that the shape of ``x`` matches ``shape``."""


### PR DESCRIPTION
To address ongoing issues relating to the monotonic errors message, as well as output predictions not being the same size as the input datasets, this PR uses np.where instead of xr.combine_by_coords() to stitch patched predictions together and output a `deepsensor.prediction` object. 

1. Create  `patchwise_pred_copy `: a new blank deepsensor prediction object at the same extent as `X_t`, where the `mean` and `std` values are set to Nan.
2. Then create a new output object `combined_dataset = patchwise_pred_copy` - this step can probably be removed, but i am being over cautious.
3. Iterates through the patchwise predictions in `patches_clipped`, and use `np.where() `to change the values of  the blank deepsensor object, `combined_dataset` to the values in the patchwise prediction values.
4. When the loop is applied to the first patch, because `combined_dataset` contains all Nans, then all the values in the first patch are used. After this point, if there is overlap between the subsequent patch and earlier patches, the values are only used in places where there isn't an overlap. This is achieved using  `combined_array[var].where(np.isnan(reindexed_patch), reindexed_patch)`

Secondary benefits of this include:

- I have been able to remove all the `+1 `because it doesn't matter if there is slight overlap between adjacent patches now as `np.where()` will handle this
- We will not get  monotonic errors because we're not using `combine_by_coords()`
- The output will always definitely be the same size as the input because the output dimensions are defined using `X_t` as described in point 1.

Some examples of the differences between outputs using `predict()` and `predict_patchwise()`. So there are some artefects, but the values range +-0.06 when temperature ranges 260-300 degrees. 
patch = 0.5, stride = 0.25
![image](https://github.com/user-attachments/assets/88d8f4cd-f189-44a1-9b1a-c2f31772a582)
patch = 0.2, stride = 0.1
![image](https://github.com/user-attachments/assets/a71094b9-3b18-47e0-9165-cb91dc9e5721)
patch = 0.3, stride = 0.13
![image](https://github.com/user-attachments/assets/5369486f-d27c-46fc-81e2-11fb24100cd1)
 
