### PR TITLE
Simplify stitching process

### DIFF
--- a/deepsensor/model/model.py
+++ b/deepsensor/model/model.py
@@ -810,25 +810,28 @@ class DeepSensorModel(ProbabilisticModel):
                 ),
             )
 
-        def get_coordinate_extent(ds, x1_ascend, x2_ascend) -> float:
+        def get_coordinate_extent(ds, x1_ascend, x2_ascend) -> tuple:
             """
             Get coordinate extent of dataset. This method is applied to either X_t or patchwise predictions. 
 
             Parameters
             ----------
-            ds (:class:`xarray.Dataset` | :class:`xarray.DataArray` | :class:`pandas.DataFrame` | :class:`pandas.Series` | :class:`pandas.Index` | :class:`numpy:numpy.ndarray`):
-                Data array to determine coordinate extent for
+            ds : Data object
+                The dataset or data array to determine coordinate extent for.
+                Refer to `X_t` in `predict_patchwise()` for supported types.
 
-            x1_ascend : str:
-                Boolean defining whether the x1 coords ascend (increase) from top to bottom, default = True.
+            x1_ascend : bool
+                Whether the x1 coordinates ascend (increase) from top to bottom.
 
-            x2_ascend : str:
-                Boolean defining whether the x2 coords ascend (increase) from left to right, default = True.
+            x2_ascend : bool
+                Whether the x2 coordinates ascend (increase) from left to right.
 
-            Returns:
+            Returns
             -------
-            
+            tuple of tuples:
+                Extents of x1 and x2 coordinates as ((min_x1, max_x1), (min_x2, max_x2)).
             """
+            
             if x1_ascend:
                 ds_x1_coords = (
                     ds.coords[orig_x1_name].min().values,

--- a/deepsensor/model/model.py
+++ b/deepsensor/model/model.py
@@ -910,7 +910,7 @@ class DeepSensorModel(ProbabilisticModel):
 
             data_x1_index, data_x2_index = get_index(data_x1, data_x2)
             patches_clipped = {var_name: [] for var_name in patch_preds[0].keys()}
-
+            print(patches_clipped)
             for i, patch_pred in enumerate(patch_preds):
                 for var_name, data_array in patch_pred.items():
                     if var_name in patch_pred:
@@ -943,10 +943,9 @@ class DeepSensorModel(ProbabilisticModel):
                         # Do not remove border for the patches along top and left of dataset and change overlap size for last patch in each row and column.
                         if patch_x2_index[0] == data_x2_index[0]:
                             b_x2_min = 0
-                            # TODO: Try to resolve this issue in data/loader.py by ensuring patches are perfectly square.
                             b_x2_max = b_x2_max
 
-                        # At end of row (when patch_x2_index = data_x2_index), to calculate the number of pixels to remove from left hand side of patch:
+                        # At end of row (when patch_x2_index = data_x2_index), calculate the number of pixels to remove from left hand side of patch.
                         elif patch_x2_index[1] == data_x2_index[1]:
                             b_x2_max = 0
                             patch_row_prev = preds[i - 1]
@@ -979,7 +978,7 @@ class DeepSensorModel(ProbabilisticModel):
 
                         if patch_x1_index[0] == data_x1_index[0]:
                             b_x1_min = 0
-                        # TODO: ensure this elif statement is robust to multiple patch sizes.
+                        
                         elif abs(patch_x1_index[1] - data_x1_index[1]) < 2:
                             b_x1_max = 0
                             b_x1_max = b_x1_max
@@ -1025,10 +1024,10 @@ class DeepSensorModel(ProbabilisticModel):
                         )
 
                         patches_clipped[var_name].append(patch_clip)
-
+            
             # Create blank prediction
             combined_dataset = copy.deepcopy(patches_clipped)
-
+            
             # Generate new blank DeepSensor.prediction object with same extent and coordinate system as X_t.
             for var, data_array_list in combined_dataset.items():
                 first_patchwise_pred = data_array_list[0]
@@ -1192,7 +1191,7 @@ class DeepSensorModel(ProbabilisticModel):
             prediction[var_name_copy] = stitched_preds
             prediction[var_name_copy] = stitched_prediction[var_name_copy]
 
-        return prediction
+        return prediction, stitched_prediction
 
 
 def add_valid_time_coord_to_pred_and_move_time_dims(pred: Prediction) -> Prediction:

--- a/deepsensor/model/model.py
+++ b/deepsensor/model/model.py
@@ -810,7 +810,7 @@ class DeepSensorModel(ProbabilisticModel):
                 ),
             )
 
-        def get_coordinate_extent(ds, x1_ascend, x2_ascend) -> tuple:
+        def get_coordinate_extent(ds: Union[xr.DataArray, xr.Dataset], x1_ascend: bool, x2_ascend: bool) -> tuple:
             """
             Get coordinate extent of dataset. This method is applied to either X_t or patchwise predictions. 
 

--- a/deepsensor/model/model.py
+++ b/deepsensor/model/model.py
@@ -1044,11 +1044,9 @@ class DeepSensorModel(ProbabilisticModel):
                     coords={
                         orig_x1_name: X_t[orig_x1_name],
                         orig_x2_name: X_t[orig_x2_name],
+                        "time": stitched_prediction[0]["time"],
                     }
                 )
-
-                # Set prediction object to same as the first patched prediction.
-                blank_ds["time"] = data_array["time"]
 
                 # Set data variable names e.g. mean, std to those in patched prediction. Make all values Nan.
                 for data_var in data_array.data_vars:


### PR DESCRIPTION
Amendments made to model.py

1. Create the new method get_coordinate_extent() to reduce code duplication. The method can calculate the coordinate extents of both `X_t` and individual patches.
2. Generate the `stitched_predictions` object, which is a `deepsensor.prediction` object immediately after slicing all patchwise predictions. Then merge the patchwise predictions to `stitched_predictions` using `.where()`. This reduces some of the code and mean that the method `stitch_clipped_predictions()` returns a `deepsensor.prediction` object.
3. Some of minor edits to markup text to hopefully make it easier to follow the codebase. 